### PR TITLE
Feature/gemini/usersetting for model

### DIFF
--- a/backend/Controllers/UserSettingsController.cs
+++ b/backend/Controllers/UserSettingsController.cs
@@ -1,0 +1,49 @@
+
+using AiRoleplayChat.Backend.Models;
+using AiRoleplayChat.Backend.Services;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AiRoleplayChat.Backend.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class UserSettingsController : BaseApiController
+    {
+        private readonly IUserSettingsService _userSettingsService;
+
+        public UserSettingsController(IUserService userService, IUserSettingsService userSettingsService, ILogger<UserSettingsController> logger)
+            : base(userService, logger)
+        {
+            _userSettingsService = userSettingsService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<List<UserSettingDto>>> GetUserSettings(CancellationToken cancellationToken)
+        {
+            var (userId, errorResult) = await GetCurrentAppUserIdAsync(cancellationToken);
+            if (errorResult != null) return errorResult;
+
+            var settings = await _userSettingsService.GetUserSettingsAsync(userId!.Value);
+            return Ok(settings);
+        }
+
+        [HttpPut]
+        public async Task<IActionResult> UpdateUserSettings([FromBody] List<UserSettingDto> settings, CancellationToken cancellationToken)
+        {
+            var (userId, errorResult) = await GetCurrentAppUserIdAsync(cancellationToken);
+            if (errorResult != null) return errorResult;
+
+            var success = await _userSettingsService.UpdateUserSettingsAsync(userId!.Value, settings);
+            if (success)
+            {
+                return NoContent();
+            }
+            else
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, "Failed to update user settings.");
+            }
+        }
+    }
+}

--- a/backend/Data/AppDbContext.cs
+++ b/backend/Data/AppDbContext.cs
@@ -10,6 +10,7 @@ public class AppDbContext : DbContext
     public DbSet<ChatMessage> ChatMessages { get; set; } = null!;
     public DbSet<ChatSession> ChatSessions { get; set; } = null!;
     public DbSet<User> Users { get; set; } = null!;
+    public DbSet<UserSetting> UserSettings { get; set; } = null!;
 
     public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
@@ -56,6 +57,11 @@ public class AppDbContext : DbContext
                   .OnDelete(DeleteBehavior.Cascade); // キャラ削除時にメッセージも削除
 
             entity.Property(e => e.Sender).HasMaxLength(10);
+        });
+
+        modelBuilder.Entity<UserSetting>(entity =>
+        {
+            entity.HasIndex(e => new { e.UserId, e.ServiceType, e.SettingKey }).IsUnique();
         });
     }
 }

--- a/backend/Data/Migrations/20250808041600_AddUserSettingsTable.Designer.cs
+++ b/backend/Data/Migrations/20250808041600_AddUserSettingsTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AiRoleplayChat.Backend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace backend.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250808041600_AddUserSettingsTable")]
+    partial class AddUserSettingsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.3");

--- a/backend/Data/Migrations/20250808041600_AddUserSettingsTable.cs
+++ b/backend/Data/Migrations/20250808041600_AddUserSettingsTable.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserSettingsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserSettings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    UserId = table.Column<int>(type: "INTEGER", nullable: false),
+                    ServiceType = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    SettingKey = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    SettingValue = table.Column<string>(type: "TEXT", maxLength: 255, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSettings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserSettings_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSettings_UserId_ServiceType_SettingKey",
+                table: "UserSettings",
+                columns: new[] { "UserId", "ServiceType", "SettingKey" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserSettings");
+        }
+    }
+}

--- a/backend/Domain/Entities/UserSetting.cs
+++ b/backend/Domain/Entities/UserSetting.cs
@@ -1,0 +1,29 @@
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AiRoleplayChat.Backend.Domain.Entities;
+
+public class UserSetting
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public int UserId { get; set; }
+
+    [ForeignKey(nameof(UserId))]
+    public virtual User User { get; set; } = null!;
+
+    [Required]
+    [StringLength(50)]
+    public string ServiceType { get; set; } = string.Empty; // e.g., "Gemini", "Replicate"
+
+    [Required]
+    [StringLength(100)]
+    public string SettingKey { get; set; } = string.Empty; // e.g., "ChatModel", "ImagePromptGenerationModel"
+
+    [Required]
+    [StringLength(255)]
+    public string SettingValue { get; set; } = string.Empty; // The actual model ID or version
+}

--- a/backend/Models/UserSettingDto.cs
+++ b/backend/Models/UserSettingDto.cs
@@ -1,0 +1,9 @@
+
+namespace AiRoleplayChat.Backend.Models;
+
+public class UserSettingDto
+{
+    public string ServiceType { get; set; } = string.Empty;
+    public string SettingKey { get; set; } = string.Empty;
+    public string SettingValue { get; set; } = string.Empty;
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -46,6 +46,7 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IChatMessageService, ChatMessageService>();
 builder.Services.AddScoped<IChatSessionService, ChatSessionService>();
 builder.Services.AddScoped<IApiKeyService, ApiKeyService>();
+builder.Services.AddScoped<IUserSettingsService, UserSettingsService>();
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>

--- a/backend/Services/ApiKeyService.cs
+++ b/backend/Services/ApiKeyService.cs
@@ -124,8 +124,10 @@ public class ApiKeyService : IApiKeyService
             {
                 if (secretProperties.Name.StartsWith(prefix) && secretProperties.Name.EndsWith(suffix))
                 {
-                    var serviceName = secretProperties.Name
+                    var serviceNameRaw = secretProperties.Name
                         .Substring(prefix.Length, secretProperties.Name.Length - prefix.Length - suffix.Length);
+                    // 最初の文字を大文字に変換して、フロントエンドの期待値と一致させる
+                    var serviceName = char.ToUpperInvariant(serviceNameRaw[0]) + serviceNameRaw.Substring(1);
                     services.Add(serviceName);
                 }
             }

--- a/backend/Services/IUserSettingsService.cs
+++ b/backend/Services/IUserSettingsService.cs
@@ -1,0 +1,13 @@
+
+using AiRoleplayChat.Backend.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AiRoleplayChat.Backend.Services
+{
+    public interface IUserSettingsService
+    {
+        Task<List<UserSettingDto>> GetUserSettingsAsync(int userId);
+        Task<bool> UpdateUserSettingsAsync(int userId, List<UserSettingDto> settings);
+    }
+}

--- a/backend/Services/UserSettingsService.cs
+++ b/backend/Services/UserSettingsService.cs
@@ -57,9 +57,17 @@ namespace AiRoleplayChat.Backend.Services
                     });
                 }
             }
-
-            await _context.SaveChangesAsync();
-            return true;
+            try
+            {
+                await _context.SaveChangesAsync();
+                return true;
+            }
+            catch (DbUpdateException ex)
+            {
+                // エラーログを出力
+                Console.Error.WriteLine($"Error updating user settings for user {userId}: {ex.Message}");
+                return false;
+            }
         }
     }
 }

--- a/backend/Services/UserSettingsService.cs
+++ b/backend/Services/UserSettingsService.cs
@@ -1,0 +1,65 @@
+
+using AiRoleplayChat.Backend.Data;
+using AiRoleplayChat.Backend.Domain.Entities;
+using AiRoleplayChat.Backend.Models;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AiRoleplayChat.Backend.Services
+{
+    public class UserSettingsService : IUserSettingsService
+    {
+        private readonly AppDbContext _context;
+
+        public UserSettingsService(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<UserSettingDto>> GetUserSettingsAsync(int userId)
+        {
+            return await _context.UserSettings
+                .Where(s => s.UserId == userId)
+                .Select(s => new UserSettingDto
+                {
+                    ServiceType = s.ServiceType,
+                    SettingKey = s.SettingKey,
+                    SettingValue = s.SettingValue
+                })
+                .ToListAsync();
+        }
+
+        public async Task<bool> UpdateUserSettingsAsync(int userId, List<UserSettingDto> settings)
+        {
+            var existingSettings = await _context.UserSettings
+                .Where(s => s.UserId == userId)
+                .ToListAsync();
+
+            foreach (var settingDto in settings)
+            {
+                var existingSetting = existingSettings.FirstOrDefault(s =>
+                    s.ServiceType == settingDto.ServiceType && s.SettingKey == settingDto.SettingKey);
+
+                if (existingSetting != null)
+                {
+                    existingSetting.SettingValue = settingDto.SettingValue;
+                }
+                else
+                {
+                    _context.UserSettings.Add(new UserSetting
+                    {
+                        UserId = userId,
+                        ServiceType = settingDto.ServiceType,
+                        SettingKey = settingDto.SettingKey,
+                        SettingValue = settingDto.SettingValue
+                    });
+                }
+            }
+
+            await _context.SaveChangesAsync();
+            return true;
+        }
+    }
+}

--- a/frontend/src/components/Notification.module.css
+++ b/frontend/src/components/Notification.module.css
@@ -1,0 +1,97 @@
+.notificationContainer {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.notification {
+  width: 300px;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  animation: slideIn 0.3s ease-out;
+  color: #fff;
+}
+
+.notification.closing {
+  animation: slideOut 0.3s ease-in forwards;
+}
+
+.notification.success {
+  background-color: #28a745; /* Green */
+}
+
+.notification.error {
+  background-color: #dc3545; /* Red */
+}
+
+.notification.loading {
+  background-color: #6c757d; /* Gray */
+}
+
+.message {
+  flex-grow: 1;
+  margin-right: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.2rem;
+  cursor: pointer;
+  opacity: 0.7;
+  padding: 0;
+  line-height: 1;
+}
+
+.closeButton:hover {
+  opacity: 1;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slideOut {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+}
+
+.spinner {
+  width: 1.2em;
+  height: 1.2em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/components/Notification.tsx
+++ b/frontend/src/components/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import styles from './Notification.module.css';
 
 export interface NotificationProps {
@@ -12,24 +12,22 @@ export interface NotificationProps {
 const Notification: React.FC<NotificationProps> = ({ id, message, type, onClose, duration = 5000 }) => {
   const [isClosing, setIsClosing] = useState(false);
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setIsClosing(true);
     setTimeout(() => {
       onClose(id);
     }, 300); // Animation duration
-  };
+  }, [id, onClose]);
 
   useEffect(() => {
     if (type !== 'loading') {
-      const timer = setTimeout(() => {
-        handleClose();
-      }, duration);
+      const timer = setTimeout(handleClose, duration);
 
       return () => {
         clearTimeout(timer);
       };
     }
-  }, [id, type, duration, onClose]);
+  }, [type, duration, handleClose]);
 
   return (
     <div className={`${styles.notification} ${styles[type]} ${isClosing ? styles.closing : ''}`}>

--- a/frontend/src/components/Notification.tsx
+++ b/frontend/src/components/Notification.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import styles from './Notification.module.css';
+
+export interface NotificationProps {
+  id: string;
+  message: string;
+  type: 'success' | 'error' | 'loading';
+  onClose: (id: string) => void;
+  duration?: number;
+}
+
+const Notification: React.FC<NotificationProps> = ({ id, message, type, onClose, duration = 5000 }) => {
+  const [isClosing, setIsClosing] = useState(false);
+
+  const handleClose = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      onClose(id);
+    }, 300); // Animation duration
+  };
+
+  useEffect(() => {
+    if (type !== 'loading') {
+      const timer = setTimeout(() => {
+        handleClose();
+      }, duration);
+
+      return () => {
+        clearTimeout(timer);
+      };
+    }
+  }, [id, type, duration, onClose]);
+
+  return (
+    <div className={`${styles.notification} ${styles[type]} ${isClosing ? styles.closing : ''}`}>
+      <div className={styles.message}>
+        {type === 'loading' && <div className={styles.spinner}></div>}
+        <span>{message}</span>
+      </div>
+      {type !== 'loading' && (
+        <button onClick={handleClose} className={styles.closeButton}>
+          &times;
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default Notification;

--- a/frontend/src/context/NotificationContext.tsx
+++ b/frontend/src/context/NotificationContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useState, useCallback, ReactNode } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import Notification, { NotificationProps } from '../components/Notification';
+import styles from '../components/Notification.module.css'; // For the container
+
+type NotificationData = Omit<NotificationProps, 'id' | 'onClose'>;
+
+interface NotificationContextType {
+  addNotification: (notification: NotificationData) => string; // Returns ID
+  removeNotification: (id: string) => void;
+}
+
+export const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
+
+export const NotificationProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [notifications, setNotifications] = useState<Omit<NotificationProps, 'onClose'>[]>([]);
+
+  const removeNotification = useCallback((id: string) => {
+    setNotifications((current) => current.filter((n) => n.id !== id));
+  }, []);
+
+  const addNotification = useCallback((notification: NotificationData): string => {
+    const id = uuidv4();
+    setNotifications((current) => [...current, { id, ...notification }]);
+    return id;
+  }, []);
+
+  return (
+    <NotificationContext.Provider value={{ addNotification, removeNotification }}>
+      {children}
+      <div className={styles.notificationContainer}>
+        {notifications.map((n) => (
+          <Notification key={n.id} {...n} onClose={removeNotification} />
+        ))}
+      </div>
+    </NotificationContext.Provider>
+  );
+};

--- a/frontend/src/hooks/useApiKeys.ts
+++ b/frontend/src/hooks/useApiKeys.ts
@@ -79,6 +79,7 @@ export const useApiKeys = (): UseApiKeysResult => {
       const errorMessage = getGenericErrorMessage(err, 'APIキー情報の取得');
       setError(errorMessage);
       console.error('Failed to get user API keys:', err);
+      setRegisteredServices([]); // ★ エラー時に配列をクリア
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/hooks/useNotification.ts
+++ b/frontend/src/hooks/useNotification.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { NotificationContext } from '../context/NotificationContext';
+
+export const useNotification = () => {
+  const context = useContext(NotificationContext);
+  if (context === undefined) {
+    throw new Error('useNotification must be used within a NotificationProvider');
+  }
+  return context;
+};

--- a/frontend/src/hooks/useUserSettings.ts
+++ b/frontend/src/hooks/useUserSettings.ts
@@ -1,0 +1,113 @@
+
+import { useState, useCallback } from 'react';
+import { useAuth } from './useAuth';
+import { getApiErrorMessage, getGenericErrorMessage } from '../utils/errorHandler';
+
+// このフックが扱う設定の型を定義
+export interface UserSetting {
+  serviceType: string;
+  settingKey: string;
+  settingValue: string;
+}
+
+interface UseUserSettingsReturn {
+  settings: UserSetting[];
+  isLoading: boolean;
+  error: string | null;
+  fetchUserSettings: () => Promise<void>;
+  updateUserSettings: (settings: UserSetting[]) => Promise<boolean>;
+  clearError: () => void;
+}
+
+export const useUserSettings = (): UseUserSettingsReturn => {
+  const { acquireToken } = useAuth();
+  const [settings, setSettings] = useState<UserSetting[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  const makeAuthenticatedRequest = useCallback(async (
+    url: string,
+    options: RequestInit = {}
+  ): Promise<Response> => {
+    const token = await acquireToken();
+    if (!token) {
+      throw new Error('認証トークンの取得に失敗しました');
+    }
+
+    const baseUrl = import.meta.env.VITE_API_URL || '';
+    const response = await fetch(`${baseUrl}${url}`, {
+      ...options,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+    });
+
+    return response;
+  }, [acquireToken]);
+
+  const fetchUserSettings = useCallback(async (): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await makeAuthenticatedRequest('/api/usersettings');
+      
+      if (!response.ok) {
+        const errorMessage = await getApiErrorMessage(response);
+        throw new Error(errorMessage);
+      }
+
+      const data: UserSetting[] = await response.json();
+      setSettings(data);
+    } catch (err) {
+      const errorMessage = getGenericErrorMessage(err, 'ユーザー設定の取得');
+      setError(errorMessage);
+      console.error('Failed to get user settings:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [makeAuthenticatedRequest]);
+
+  const updateUserSettings = useCallback(async (settingsToUpdate: UserSetting[]): Promise<boolean> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await makeAuthenticatedRequest('/api/usersettings', {
+        method: 'PUT',
+        body: JSON.stringify(settingsToUpdate),
+      });
+
+      if (!response.ok) {
+        const errorMessage = await getApiErrorMessage(response);
+        throw new Error(errorMessage);
+      }
+
+      // 更新成功後、最新の設定を再取得
+      await fetchUserSettings();
+      return true;
+    } catch (err) {
+      const errorMessage = getGenericErrorMessage(err, 'ユーザー設定の更新');
+      setError(errorMessage);
+      console.error('Failed to update user settings:', err);
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [makeAuthenticatedRequest, fetchUserSettings]);
+
+  return {
+    settings,
+    isLoading,
+    error,
+    fetchUserSettings,
+    updateUserSettings,
+    clearError,
+  };
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,8 +5,9 @@ import App from './App.tsx'
 import { BrowserRouter } from 'react-router-dom';
 
 import { PublicClientApplication } from '@azure/msal-browser';
-import { MsalProvider } from '@azure/msal-react';             
+import { MsalProvider } from '@azure/msal-react';
 import { msalConfig } from './authConfig.ts';
+import { NotificationProvider } from './context/NotificationContext.tsx';
 
 // MSAL の PublicClientApplication インスタンスを作成
 const msalInstance = new PublicClientApplication(msalConfig);
@@ -15,7 +16,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <MsalProvider instance={msalInstance}>
       <BrowserRouter>
-        <App />
+        <NotificationProvider>
+          <App />
+        </NotificationProvider>
       </BrowserRouter>
     </MsalProvider>
   </StrictMode>,

--- a/frontend/src/pages/SettingsPage.module.css
+++ b/frontend/src/pages/SettingsPage.module.css
@@ -171,6 +171,11 @@
   font-style: italic;
 }
 
+.apiKeyLink {
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+
 @media (max-width: 768px) {
   .container {
     padding: 1rem;

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -139,22 +139,34 @@ const SettingsPage: React.FC = () => {
         <h2>APIキーの現在の設定状況</h2>
         <div className={styles.statusGrid}>
           {SUPPORTED_SERVICES.map((service) => (
-            <div key={service} className={styles.statusItem}>
-              <strong>{service} API Key:</strong>
-              <span className={registeredApiKeys.includes(service) ? styles.statusActive : styles.statusInactive}>
-                {registeredApiKeys.includes(service) ? '登録済み' : '未登録'}
-              </span>
-              {registeredApiKeys.includes(service) && (
-                <button
-                  onClick={() => handleDeleteApiKey(service)}
-                  disabled={isLoadingApiKeys}
-                  className={styles.dangerButton}
-                >
-                  削除
-                </button>
-              )}
+            <div key={service}>
+              <div className={styles.statusItem}>
+                <strong>{service} API Key:</strong>
+                <span className={registeredApiKeys.includes(service) ? styles.statusActive : styles.statusInactive}>
+                  {registeredApiKeys.includes(service) ? '登録済み' : '未登録'}
+                </span>
+                {registeredApiKeys.includes(service) && (
+                  <button
+                    onClick={() => handleDeleteApiKey(service)}
+                    disabled={isLoadingApiKeys}
+                    className={styles.dangerButton}
+                  >
+                    削除
+                  </button>
+                )}
+              </div>
             </div>
           ))}
+        </div>
+        <div className={styles.apiKeyLink}>
+          <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener noreferrer">
+            GeminiのAPIキー取得方法はこちら
+          </a>
+        </div>
+        <div className={styles.apiKeyLink}>
+          <a href="https://replicate.com/" target="_blank" rel="noopener noreferrer">
+            ReplicateのAPIキー取得方法はこちら
+          </a>
         </div>
       </section>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useApiKeys } from '../hooks/useApiKeys';
+import { useUserSettings, UserSetting } from '../hooks/useUserSettings';
 import { useAuth } from '../hooks/useAuth';
 import styles from './SettingsPage.module.css';
+
+interface ModelSettingsForm {
+  geminiChatModel: string;
+  geminiImagePromptModel: string;
+  replicateImageModel: string;
+}
 
 interface ApiKeyForm {
   serviceName: string;
@@ -14,18 +21,29 @@ const SUPPORTED_SERVICES = ['Gemini', 'Replicate'] as const;
 const SettingsPage: React.FC = () => {
   const { isAuthenticated } = useAuth();
   const {
-    registeredServices,
+    settings,
     isLoading,
     error,
+    fetchUserSettings,
+    updateUserSettings,
+    clearError,
+  } = useUserSettings();
+
+  const { 
+    registeredServices: registeredApiKeys,
+    isLoading: isLoadingApiKeys,
+    error: apiKeyError,
     getUserApiKeys,
     registerApiKey,
     deleteApiKey,
-    clearError,
+    clearError: clearApiKeyError,
   } = useApiKeys();
 
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   // API Key form
+  const modelSettingsForm = useForm<ModelSettingsForm>();
+
   const apiKeyForm = useForm<ApiKeyForm>({
     defaultValues: {
       serviceName: 'Gemini',
@@ -33,16 +51,27 @@ const SettingsPage: React.FC = () => {
     },
   });
 
-  // Load user's API keys on mount
   useEffect(() => {
     if (isAuthenticated) {
+      fetchUserSettings();
       getUserApiKeys();
     }
-  }, [isAuthenticated, getUserApiKeys]);
+  }, [isAuthenticated, fetchUserSettings, getUserApiKeys]);
+
+  useEffect(() => {
+    if (settings) {
+      modelSettingsForm.reset({
+        geminiChatModel: settings.find(s => s.serviceType === 'Gemini' && s.settingKey === 'ChatModel')?.settingValue || '',
+        geminiImagePromptModel: settings.find(s => s.serviceType === 'Gemini' && s.settingKey === 'ImagePromptGenerationModel')?.settingValue || '',
+        replicateImageModel: settings.find(s => s.serviceType === 'Replicate' && s.settingKey === 'ImageGenerationVersion')?.settingValue || '',
+      });
+    }
+  }, [settings, modelSettingsForm.reset, modelSettingsForm]);
 
   const clearMessages = () => {
     setSuccessMessage(null);
-    clearError();
+    clearError(); // モデル設定のエラーをクリア
+    clearApiKeyError(); // APIキーのエラーをクリア
   };
 
   const handleApiKeySubmit = async (data: ApiKeyForm) => {
@@ -68,6 +97,21 @@ const SettingsPage: React.FC = () => {
     }
   };
 
+  const handleModelSettingsSubmit = async (data: ModelSettingsForm) => {
+    clearMessages();
+
+    const settingsToUpdate: UserSetting[] = [
+      { serviceType: 'Gemini', settingKey: 'ChatModel', settingValue: data.geminiChatModel },
+      { serviceType: 'Gemini', settingKey: 'ImagePromptGenerationModel', settingValue: data.geminiImagePromptModel },
+      { serviceType: 'Replicate', settingKey: 'ImageGenerationVersion', settingValue: data.replicateImageModel },
+    ];
+
+    const success = await updateUserSettings(settingsToUpdate);
+    if (success) {
+      setSuccessMessage('モデル設定が正常に更新されました。');
+    }
+  };
+
   if (!isAuthenticated) {
     return (
       <div className={styles.container}>
@@ -88,6 +132,12 @@ const SettingsPage: React.FC = () => {
         </div>
       )}
       
+      {apiKeyError && (
+        <div className={styles.errorMessage}>
+          {apiKeyError}
+        </div>
+      )}
+      
       {successMessage && (
         <div className={styles.successMessage}>
           {successMessage}
@@ -95,27 +145,28 @@ const SettingsPage: React.FC = () => {
       )}
 
       {/* Loading Indicator */}
-      {isLoading && (
+      {(isLoading || isLoadingApiKeys) && (
         <div className={styles.loading}>
           読み込み中...
         </div>
       )}
 
+
       {/* Current Status Section */}
       <section className={styles.section}>
-        <h2>現在の設定状況</h2>
+        <h2>APIキーの現在の設定状況</h2>
         
         <div className={styles.statusGrid}>
           {SUPPORTED_SERVICES.map((service) => (
             <div key={service} className={styles.statusItem}>
               <strong>{service} API Key:</strong>
-              <span className={registeredServices.includes(service) ? styles.statusActive : styles.statusInactive}>
-                {registeredServices.includes(service) ? '登録済み' : '未登録'}
+              <span className={registeredApiKeys.includes(service) ? styles.statusActive : styles.statusInactive}>
+                {registeredApiKeys.includes(service) ? '登録済み' : '未登録'}
               </span>
-              {registeredServices.includes(service) && (
+              {registeredApiKeys.includes(service) && (
                 <button
                   onClick={() => handleDeleteApiKey(service)}
-                  disabled={isLoading}
+                  disabled={isLoadingApiKeys}
                   className={styles.dangerButton}
                 >
                   削除
@@ -170,8 +221,52 @@ const SettingsPage: React.FC = () => {
             )}
           </div>
           
-          <button type="submit" disabled={isLoading} className={styles.primaryButton}>
+          <button type="submit" disabled={isLoadingApiKeys} className={styles.primaryButton}>
             APIキーを登録
+          </button>
+        </form>
+      </section>
+
+      {/* Model Settings Section */}
+      <section className={styles.section}>
+        <h2>モデル設定</h2>
+        <p className={styles.description}>
+          各サービスで使用するAIモデルのIDやバージョンを指定します。空欄の場合はシステムのデフォルト値が使用されます。
+        </p>
+        
+        <form onSubmit={modelSettingsForm.handleSubmit(handleModelSettingsSubmit)} className={styles.form}>
+          <div className={styles.formField}>
+            <label htmlFor="geminiChatModel">Gemini (チャット用モデル)</label>
+            <input
+              id="geminiChatModel"
+              type="text"
+              placeholder="例: gemini-2.5-flash"
+              {...modelSettingsForm.register('geminiChatModel')}
+            />
+          </div>
+
+          <div className={styles.formField}>
+            <label htmlFor="geminiImagePromptModel">Gemini (画像プロンプト生成用モデル)</label>
+            <input
+              id="geminiImagePromptModel"
+              type="text"
+              placeholder="例: gemini-2.5-flash-light"
+              {...modelSettingsForm.register('geminiImagePromptModel')}
+            />
+          </div>
+
+          <div className={styles.formField}>
+            <label htmlFor="replicateImageModel">Replicate (画像生成用モデルバージョン)</label>
+            <input
+              id="replicateImageModel"
+              type="text"
+              placeholder="例: ac732df83cea7fff18b8472768c88ad041fa750ff7682a21affe81863cbe77e4"
+              {...modelSettingsForm.register('replicateImageModel')}
+            />
+          </div>
+          
+          <button type="submit" disabled={isLoading} className={styles.primaryButton}>
+            モデル設定を保存
           </button>
         </form>
       </section>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -22,15 +22,9 @@ const SUPPORTED_SERVICES = ['Gemini', 'Replicate'] as const;
 const SettingsPage: React.FC = () => {
   const { isAuthenticated } = useAuth();
   const { addNotification, removeNotification } = useNotification();
-  const {
-    settings,
-    isLoading,
-    error,
-    fetchUserSettings,
-    updateUserSettings,
-  } = useUserSettings();
+  const { settings, isLoading, error, fetchUserSettings, updateUserSettings } = useUserSettings();
 
-  const { 
+  const {
     registeredServices: registeredApiKeys,
     isLoading: isLoadingApiKeys,
     error: apiKeyError,
@@ -57,12 +51,17 @@ const SettingsPage: React.FC = () => {
   useEffect(() => {
     if (settings) {
       modelSettingsForm.reset({
-        geminiChatModel: settings.find(s => s.serviceType === 'Gemini' && s.settingKey === 'ChatModel')?.settingValue || '',
-        geminiImagePromptModel: settings.find(s => s.serviceType === 'Gemini' && s.settingKey === 'ImagePromptGenerationModel')?.settingValue || '',
-        replicateImageModel: settings.find(s => s.serviceType === 'Replicate' && s.settingKey === 'ImageGenerationVersion')?.settingValue || '',
+        geminiChatModel:
+          settings.find((s) => s.serviceType === 'Gemini' && s.settingKey === 'ChatModel')?.settingValue || '',
+        geminiImagePromptModel:
+          settings.find((s) => s.serviceType === 'Gemini' && s.settingKey === 'ImagePromptGenerationModel')
+            ?.settingValue || '',
+        replicateImageModel:
+          settings.find((s) => s.serviceType === 'Replicate' && s.settingKey === 'ImageGenerationVersion')
+            ?.settingValue || '',
       });
     }
-  }, [settings, modelSettingsForm.reset, modelSettingsForm]);
+  }, [settings, modelSettingsForm.reset]);
 
   useEffect(() => {
     let loadingNotificationId: string | null = null;
@@ -135,7 +134,7 @@ const SettingsPage: React.FC = () => {
   return (
     <div className={styles.container}>
       <h1>設定</h1>
-      
+
       <section className={styles.section}>
         <h2>APIキーの現在の設定状況</h2>
         <div className={styles.statusGrid}>
@@ -164,7 +163,7 @@ const SettingsPage: React.FC = () => {
         <p className={styles.description}>
           外部サービスのAPIキーを登録します。キーはシステムで設定されたKey Vaultに安全に保存されます。
         </p>
-        
+
         <form onSubmit={apiKeyForm.handleSubmit(handleApiKeySubmit)} className={styles.form}>
           <div className={styles.formField}>
             <label htmlFor="serviceName">サービス</label>
@@ -190,18 +189,16 @@ const SettingsPage: React.FC = () => {
                 required: 'APIキーを入力してください',
                 minLength: {
                   value: 10,
-                  message: 'APIキーは最低10文字以上である必要があります'
-                }
+                  message: 'APIキーは最低10文字以上である必要があります',
+                },
               })}
               className={apiKeyForm.formState.errors.apiKey ? styles.errorInput : ''}
             />
             {apiKeyForm.formState.errors.apiKey && (
-              <span className={styles.fieldError}>
-                {apiKeyForm.formState.errors.apiKey.message}
-              </span>
+              <span className={styles.fieldError}>{apiKeyForm.formState.errors.apiKey.message}</span>
             )}
           </div>
-          
+
           <button type="submit" disabled={isLoadingApiKeys} className={styles.primaryButton}>
             APIキーを登録
           </button>
@@ -213,7 +210,7 @@ const SettingsPage: React.FC = () => {
         <p className={styles.description}>
           各サービスで使用するAIモデルのIDやバージョンを指定します。空欄の場合はシステムのデフォルト値が使用されます。
         </p>
-        
+
         <form onSubmit={modelSettingsForm.handleSubmit(handleModelSettingsSubmit)} className={styles.form}>
           <div className={styles.formField}>
             <label htmlFor="geminiChatModel">Gemini (チャット用モデル)</label>
@@ -244,7 +241,7 @@ const SettingsPage: React.FC = () => {
               {...modelSettingsForm.register('replicateImageModel')}
             />
           </div>
-          
+
           <button type="submit" disabled={isLoading} className={styles.primaryButton}>
             モデル設定を保存
           </button>


### PR DESCRIPTION
### 概要

現在、設定画面の機能を拡張し、現在ハードコードされているAIモデルのID/バージョンを、ユーザーが画面から個別に設定・変更できるようにします。

### 背景

- 現在、APIキーはBYOK原則に基づきユーザーが設定可能ですが、利用するAIモデルは全ユーザーで共通の設定となっています。
- 将来的に新しいAIサービスやモデルを追加する際の拡張性を高めるため、モデル設定もユーザーごとに管理できるようにする必要があります。

### タスク

#### フェーズ1: バックエンド

1.  **DBスキーマ変更:**
    -   ユーザーごとの設定を格納する新しいテーブル `UserSettings` を作成します。
    -   `UserId` (FK), `ServiceType`, `SettingKey`, `SettingValue` といったカラムを持たせます。
    -   EF Coreマイグレーションを実行します。
2.  **専用サービスの作成:**
    -   `IUserSettingsService` / `UserSettingsService` を作成し、設定の取得・更新ロジックを実装します。
3.  **APIエンドポイントの作成:**
    -   `UserSettingsController` を作成し、以下のエンドポイントを実装します。
        -   `GET /api/usersettings`: 現在のユーザー設定を取得
        -   `PUT /api/usersettings`: ユーザー設定を更新
4.  **既存サービスの修正:**
    -   `GeminiService` と `ReplicateService` が、API呼び出し時に `UserSettingsService` を経由してユーザー固有のモデル設定を読み込むように修正します。
    -   設定が存在しない場合は、`appsettings.json` のデフォルト値にフォールバックする処理を実装します。

#### フェーズ2: フロントエンド

1.  **UIの更新:**
    -   `SettingsPage.tsx` に「モデル設定」セクションを追加します。
    -   以下のモデル設定用の入力フィールドを設けます。
        -   Gemini (チャット用)
        -   Gemini (画像プロンプト生成用)
        -   Replicate (画像生成用)
    -   現在の設定値とシステムのデフォルト値を両方表示します。
2.  **API連携:**
    -   `useUserSettings.ts` カスタムフックを作成し、設定の取得・更新処理を実装します。
    -   `SettingsPage` でフックを利用し、UIとAPIを連携させます。

### 完了の定義

-   [ ] ユーザーが設定画面から各サービスの利用モデルID/バージョンを登録・更新できる。
-   [ ] AIとの対話や画像生成時に、ユーザーが設定したモデルが利用される。
-   [ ] ユーザーがモデルを設定していない場合は、システムデフォルトのモデルが利用される。
-   [ ] 上記の変更に対応するバックエンドのAPIとデータベーススキーマが実装されている。
